### PR TITLE
Enable networking during install time

### DIFF
--- a/buildroot/default.preseed
+++ b/buildroot/default.preseed
@@ -10,10 +10,10 @@ d-i console-setup/ask_detect boolean false
 d-i keymap select us
 
 ### Network configuration
-# Disable network configuration entirely. This is useful for cdrom
-# installations on non-networked devices where the network questions,
-# warning and long timeouts are a nuisance.
-d-i netcfg/enable boolean false
+#Enable network configuration
+d-i netcfg/choose_interface select auto
+d-i netcfg/disable_dhcp boolean false
+d-i netcfg/enable boolean true
 # Disable that annoying WEP key dialog.
 d-i netcfg/wireless_wep string
 d-i   hw-detect/load_firmware boolean false


### PR DESCRIPTION
This enables networking during install which is useful for debugging, getting logs off the system using nc, or doing other network related activities such as downloading additional install scripts and tools.
