### PR TITLE
ISO build works with xorriso v1.2.4+

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -95,10 +95,11 @@ if [ -f ${ISOPATH}/${ISONAME} ]; then
 	rm -f "${ISOPATH}/${ISONAME}"
 fi
 
+echo "Building ${ISOPATH}/${ISONAME} ..."
 xorriso -as mkisofs -r -checksum_algorithm_iso md5,sha1,sha256,sha512 \
 	-V 'Ye Olde SteamOSe 1.0b1a1' -o ${ISOPATH}/${ISONAME} \
 	-J -isohybrid-mbr /usr/lib/syslinux/isohdpfx.bin \
-	-J -joliet-long -cache-inodes -b isolinux/isolinux.bin \
+	-joliet-long -b isolinux/isolinux.bin \
 	-c isolinux/boot.cat -no-emul-boot -boot-load-size 4 \
 	-boot-info-table -eltorito-alt-boot -e boot/grub/efi.img \
-	-no-emul-boot -isohybrid-gpt-basdat -isohybrid-apm-hfsplus $BUILD
+	-no-emul-boot -isohybrid-gpt-basdat -isohybrid-apm-hfsplus ${BUILD}


### PR DESCRIPTION
Found out I needed a newer version of xorriso to build the iso properly (https://lists.gnu.org/archive/html/info-gnu/2012-07/msg00012.html shows tha tthe -isohybrid-gpt-basdat -isohybrid-apm-hfsplus -isohybrid-gpt-basdat flags were added then and not in Ubuntu 12.04).

Cleaned up an extra -J flag and added some output.

While installing with the ISO, there's a failure of base-install, which works if you click continue and re-try the install from the menu. Not sure if this is because of a package dependency or something else with the repo.
