### PR TITLE
README: Use /dev/rdiskN in the Mac instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Just burn the ISO to a blank DVD from your favourite tool, and boot it.
 
 Open a Terminal window from the Utilities section of Applications.
 
-Type `diskutil list` to get a list of devices - one of them will be your USB stick (e.g. `/dev/disk2`). Follow the Linux instructions below, with this `/dev/diskX` entry instead of `/dev/sdX`
+Type `diskutil list` to get a list of devices - one of them will be your USB stick (e.g. `/dev/disk2`). Follow the Linux instructions below, with this `/dev/rdiskX` entry instead of `/dev/sdX`
 
 ## Installing from USB (Linux)
 


### PR DESCRIPTION
Using `/dev/rdiskX` instead of `/dev/diskX` accelerates the copy process a lot.
