### PR TITLE
index.html: Use /dev/rdiskX in the Mac instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
 <p>Open a Terminal window from the Utilities section of Applications.</p>
 
-<p>Type &quot;diskutil list&quot; to get a list of devices - one of them will be your USB stick (e.g. /dev/disk2). Follow the Linux instructions below, with this /dev/diskX entry instead of /dev/sdX</p>
+<p>Type &quot;diskutil list&quot; to get a list of devices - one of them will be your USB stick (e.g. /dev/disk2). Follow the Linux instructions below, with this /dev/rdiskX entry instead of /dev/sdX (please note the added "r"!)</p>
 
 <h4>Installing from USB (Linux)</h4>
 


### PR DESCRIPTION
Using `/dev/rdiskX` instead of `/dev/diskX` accelerates the copy process a lot.
