### PR TITLE
Fix plymouth for bios systems

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -133,6 +133,7 @@ echo "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash\"" >> /target/etc/default/grub
 else
 echo "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash vga=0x318\"" >> /target/etc/default/grub
 fi
+
 cat - >> /target/etc/grub.d/40_custom << EOF
 menuentry "Capture System Partition"{
   search --set -f /live-hd/vmlinuz


### PR DESCRIPTION
This sets the framebuffer size to 1024x768x24 on bios systems. It won't look amazing on 1080p displays, but the low resolution should work on 1600x900 and 1280x720 screens. It doesn't look stretched at least.
