### PR TITLE
Updated for new directory layout archive-mirror

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -12,7 +12,7 @@ UPSTREAMURL="http://repo.steampowered.com"
 STEAMINSTALLFILE="SteamOSDVD.iso"
 MD5SUMFILE="MD5SUMS"
 KNOWNINSTALLER="e0583f17ea8f6d5307b74a0d28a99a5e"
-REPODIR="./archive-mirror/"
+REPODIR="./archive-mirror/mirror/repo.steampowered.com/steamos"
 
 #Show how to use gen.sh
 usage ( )


### PR DESCRIPTION
Required for obsolete report to function after switching archive-mirror.sh to apt-mirror.
