### PR TITLE
Fix AMD gpu users booting into black screen

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -83,6 +83,14 @@ X-GNOME-Autostart-enabled=true
 Name=postlogon
 EOF
 
+#
+# Run aticonfig if an AMD card is present
+#
+if [ -n "$(lspci|grep VGA|grep -i 'AMD\|ATI')" ]; then
+  if [ ! -n "$(lspci|grep VGA|grep NVIDIA)" ]; then
+    chroot /target update-alternatives --set glx /usr/lib/fglrx
+  fi
+fi
 
 #
 # Boot splash screen and GRUB configuration


### PR DESCRIPTION
Without this patch, AMD gpu users boot into a black screen on the first boot after installing Stephenson's Rocket. It checks if an AMD gpu is in the system and if no NVidia gpu is in the system, if both are true radeon is blacklisted. This prevents the radeon driver from locking up the system.