### PR TITLE
i386 packages will now also be pulled

### DIFF
--- a/archive-mirror.sh
+++ b/archive-mirror.sh
@@ -29,6 +29,8 @@ set nthreads     20
 set _tilde 0
 deb http://repo.steampowered.com/steamos alchemist main contrib non-free
 deb http://repo.steampowered.com/steamos alchemist_beta main contrib non-free
+deb-i386 http://repo.steampowered.com/steamos alchemist main contrib non-free
+deb-i386 http://repo.steampowered.com/steamos alchemist_beta main contrib non-free
 clean http://repo.steampowered.com/steamos
 EOF
 


### PR DESCRIPTION
This adds 3.9 gb to the mirror, but this does make obsoletereport more useful.
